### PR TITLE
Supress lnum error

### DIFF
--- a/autoload/easy_replace.vim
+++ b/autoload/easy_replace.vim
@@ -129,12 +129,21 @@ fun! easy_replace#exit()
   endif
 
   stopinsert
-  bwipeout!
+  try
+    if buflisted(bufnr('%'))
+      bwipeout!
+    endif
+  catch /^Vim\%((\a\+)\)\=:E315/
+  endtry
 
   call easy_replace#stop_highlight()
 endfun
 
 fun! easy_replace#stop_highlight()
+  if win_id2win(s:context.origin_window_id) == -1
+    return
+  endif
+
   call win_gotoid(s:context.origin_window_id)
   match none
 endfun
@@ -148,7 +157,7 @@ fun! easy_replace#create_window()
   inoremap <buffer> <silent> <ESC> <ESC>:call easy_replace#exit()<CR>
   inoremap <buffer> <silent> <CR> <ESC>:call easy_replace#next_mode()<CR>
   autocmd TextChangedI,TextChangedP <buffer> call easy_replace#update_char()
-  autocmd BufWinLeave <buffer> call easy_replace#stop_highlight()
+  autocmd BufWinLeave <buffer> if buflisted(bufnr('%')) | try | call easy_replace#stop_highlight() | catch /^Vim\%((\a\+)\)\=:E315/ | endtry | endif
 endfun
 
 fun! easy_replace#echo_status()


### PR DESCRIPTION
Since [Neovim v0.10.1](https://github.com/neovim/neovim/releases/tag/v0.10.1), users might encounter the following error when close a buffer of `vim-easy-replace` :

```vim
Error detected while processing function easy_replace#exit[6]..DiagnosticChanged Autocommands f
or "*":
E315: ml_get: Invalid lnum: 1
E315: ml_get: Invalid lnum: 1
E315: ml_get: Invalid lnum: 1
E315: ml_get: Invalid lnum: 1
E315: ml_get: Invalid lnum: 1
E315: ml_get: Invalid lnum: 1
E315: ml_get: Invalid lnum: 1
E315: ml_get: Invalid lnum: 1
E315: ml_get: Invalid lnum: 1
E315: ml_get: Invalid lnum: 1
E315: ml_get: Invalid lnum: 1
E315: ml_get: Invalid lnum: 1
Press ENTER or type command to
```

This PR addresses the suppression of this error, improving the user experience and more.